### PR TITLE
fix# 4004

### DIFF
--- a/templates/committees/committeemeeting_detail.html
+++ b/templates/committees/committeemeeting_detail.html
@@ -33,7 +33,7 @@
             <li><a href="{% url committee-list %}">{% trans "Committees" %}</a> <span class="divider">/</span></li>
         {% endifnotequal %}
         <li><a href="{{ object.committee.get_absolute_url }}">{{ object.committee }}</a> <span class="divider">/</span></l1>
-        <li class="active">{{object.topics}}</li>
+        <li class="active">{{object.topics|safe}}</li>
 {% endblock %}
 
 {% block messages %}


### PR DESCRIPTION
The phrase '|safe' was added to '<li class="active">{{object.topics|safe}}</li>'
in file templates\committees\committeemeeting_detail.html
so that the template won't change whitespace after number bullets into '&nbsp;'.
