### PR TITLE
Task #4004: added 'safe' to escape the nbsp characters

### DIFF
--- a/templates/committees/committeemeeting_detail.html
+++ b/templates/committees/committeemeeting_detail.html
@@ -32,8 +32,8 @@
         {% ifnotequal object.committee.type 'plenum' %}
             <li><a href="{% url committee-list %}">{% trans "Committees" %}</a> <span class="divider">/</span></li>
         {% endifnotequal %}
-        <li><a href="{{ object.committee.get_absolute_url }}">{{ object.committee }}</a> <span class="divider">/</span></l1>
-        <li class="active">{{object.topics}}</li>
+        <li><a href="{{ object.committee.get_absolute_url }}">{{ object.committee }}</a> <span class="divider">/</span></li>
+        <li class="active">{{object.topics|safe}}</li>
 {% endblock %}
 
 {% block messages %}


### PR DESCRIPTION
also fixed typo l1 tag (non-symptomatic)
