### PR TITLE
make syncdata attach only committees to laws (not plenum) 

### DIFF
--- a/simple/management/commands/syncdata.py
+++ b/simple/management/commands/syncdata.py
@@ -1300,7 +1300,7 @@ class Command(NoArgsCommand):
         """
 
         d = datetime.date.today()-datetime.timedelta(60) # only look through cms in last 60 days.
-        for cm in CommitteeMeeting.objects.filter(date__gt=d).exclude(protocol_text=None):
+        for cm in CommitteeMeeting.objects.filter(date__gt=d,committee__type='committee').exclude(protocol_text=None):
             c = cannonize(cm.protocol_text)
             for gp in gps:
                 if c.find(gp['c1'])>=0 or c.find(gp['c2'])>=0:


### PR DESCRIPTION
to fix this bug: https://groups.google.com/forum/?fromgroups=#!topic/oknesset-dev/Mzamy4UwiRw

after merging need to remove existing plenum meetings from laws
can be done manually because there should only be a few of these
# get all bills with plenum meetings in them:

first=Bill.objects.filter(first_committee_meetings__committee__type='plenum')
second=Bill.objects.filter(second_committee_meetings__committee__type='plenum')
# for each bill:
# b=first[0]

b.first_committee_meetings.remove(b.first_committee_meetings.filter(committee__type='plenum'))
# b=second[0]

b.second_committee_meetings.remove(b.second_committee_meetings.filter(committee__type='plenum'))
