### PR TITLE
fix 116: vote api will return null for image url if it's missing

### DIFF
--- a/laws/api.py
+++ b/laws/api.py
@@ -88,7 +88,7 @@ class VoteResource(BaseResource):
 
             agenda_bundle = {
                 'name': agenda.name,
-                'image': agenda.image.url,
+                'image': agenda.image.url if agenda.image else None,
                 'resource_uri': resource_uri,
                 'score': avote.score,
                 'importance': avote.importance,


### PR DESCRIPTION
also added a test to see that a vote with an agenda is returned without
error.

oh, and automatically removed whitespace from some line endings
