### PR TITLE
update workflow tutorial - ssh keys for master pull

### DIFF
--- a/docs/devel/source/workflow.rst
+++ b/docs/devel/source/workflow.rst
@@ -31,6 +31,12 @@ Enter the `Open-Knesset` directory, and run:
 .. code-block:: sh
 
     git pull git@github.com:hasadna/Open-Knesset.git master
+    
+.. note::
+
+    Running this command requires having SSH keys registered with github. If you don't have these, or
+    if you don't understand what this means and do not want to look it up, you can replace 'git@' with
+    'https://' and everything should work properly.
 
 If `requirements.txt` was modified, make sure all of them are installed (no harm
 running this command event in case of no changes):


### PR DESCRIPTION
Added a note regarding the need for SSH keys to be registered with github in order to use the given pull command, and the option to use https instead.
