### PR TITLE
fix #223 annotations break with infinite scroll

### DIFF
--- a/static/js/committeemeeting_detail.js
+++ b/static/js/committeemeeting_detail.js
@@ -42,7 +42,7 @@ $(function(){
         annotation_objects[a].importQuotes();
         annotation_objects[a].insertQuotes();
     }
-    $(".annotationform-link").live("click", function(e){
+    $(document).on("click", ".annotationform-link", function(e){
       e.preventDefault();
       if (!window.logged_in) {
           var msg = gettext("Sorry, only logged users can annotate.");


### PR DESCRIPTION
- change .click() to .live() to attach the event for
  future annotations as well
- When appending new annotations to page, add them
  to annotaion_objects array
