### PR TITLE
Allowed /api/event/icalendar/ in robots.txt

### DIFF
--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,6 +1,7 @@
 User-agent: *
 Disallow: /users/*
 Disallow: /ajax/hit/
+Allow: /api/event/icalendar/
 Disallow: /api/*
 Crawl-delay: 60
 


### PR DESCRIPTION
So Google calendar can read the ICAL file.
