### PR TITLE
added a scrapers status page - which shows exactly when scrapers failed

### DIFF
--- a/auxiliary/urls.py
+++ b/auxiliary/urls.py
@@ -1,0 +1,9 @@
+#encoding: UTF-8
+from django.conf.urls import url, patterns
+from views import MainScraperStatusView, ScraperRunDetailView
+
+
+auxiliarysurlpatterns = patterns('',
+    url(r'^scrapers/$', MainScraperStatusView.as_view(), name='main-scrapers-status'),
+    url(r'^scraper/(?P<pk>\d+)$', ScraperRunDetailView.as_view(), name='scraper-log'),
+)

--- a/knesset/urls.py
+++ b/knesset/urls.py
@@ -23,6 +23,7 @@ from mks.views import get_mk_entry, mk_is_backlinkable
 from laws.models import Bill
 from polyorg.urls import polyorgurlpatterns
 from lobbyists.urls import lobbyistpatterns
+from auxiliary.urls import auxiliarysurlpatterns
 
 from auxiliary.views import (
     main, post_annotation, post_details, post_feedback,
@@ -109,3 +110,4 @@ urlpatterns += staticfiles_urlpatterns() + static(settings.MEDIA_URL, document_r
 # seems broken, specially when trying to cache querysets
 # urlpatterns += polyorgurlpatterns + personsurlpatterns
 urlpatterns += personsurlpatterns
+urlpatterns += auxiliarysurlpatterns

--- a/templates/auxiliary/main_scraper_status.html
+++ b/templates/auxiliary/main_scraper_status.html
@@ -1,0 +1,27 @@
+{% extends "site_base.html" %}
+{% load i18n %}
+{% block extratitle %}{% trans 'Scrapers Status' %}{% endblock %}
+{% block keywords %}{% trans 'Scrapers Status' %}{% endblock %}
+{% block description %}{% trans 'Scrapers Status' %} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
+{% block breadcrumbs %}
+        <li><a href="{% url 'main-scrapers-status' %}">{% trans "Scrapers Status" %}</a></li>
+{% endblock %}
+{% block divcontent %}
+    <div class="row">
+        <div class="cards">
+            <div class="card card-list compact">
+                <header><h2>{% trans 'Last scraper logs' %}</h2></header>
+                <ul>
+                    {% for object in object_list %}
+                        <li>
+                            <p class="item-context">{{ object.start_time }}</p>
+                            <a href="{% url 'scraper-log' object.id %}">{{ object.scraper_label}} - {{ object.status }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+

--- a/templates/auxiliary/scraper_run_detail.html
+++ b/templates/auxiliary/scraper_run_detail.html
@@ -1,0 +1,25 @@
+{% extends "site_base.html" %}
+{% load i18n %}
+{% block extratitle %}{% trans 'Scraper Run Detail' %}{% endblock %}
+{% block keywords %}{% trans 'Scraper Run Detail' %}{% endblock %}
+{% block description %}{% trans 'Scraper Run Detail' %} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
+{% block breadcrumbs %}
+        <li><a href="{% url 'main-scrapers-status' %}">{% trans "Scrapers Status" %}</a> <span class="divider">/</span></li>
+        <li><a href="#">{{ object }}</a></li>
+{% endblock %}
+{% block divcontent %}
+    <div class="row">
+        <div class="cards">
+            <div class="card card-list compact">
+                <header><h2>{{ object }}</h2></header>
+                <ul>
+                    <li>
+                        <pre dir="ltr" style="text-align:left;">{% for log in object.logs.all %}{{ log }}{% endfor %}</pre>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+


### PR DESCRIPTION
This page shows okscraper status - it allows anyone to see if / when scrapers failed and also to dig in and see exactly why they failed.

When merged it will be availabled at this url:
http://oknesset.org/scrapers
