### PR TITLE
Facebook canvas support - for Open-Subs

### DIFF
--- a/knesset/settings.py
+++ b/knesset/settings.py
@@ -155,6 +155,7 @@ INSTALLED_APPS = (
     'crispy_forms',
     'storages',
     'corsheaders',
+    'sslserver',
     #'knesset',
     'auxiliary',                  # knesset apps
     'mks',

--- a/knesset/settings.py
+++ b/knesset/settings.py
@@ -155,7 +155,6 @@ INSTALLED_APPS = (
     'crispy_forms',
     'storages',
     'corsheaders',
-    'sslserver',
     #'knesset',
     'auxiliary',                  # knesset apps
     'mks',
@@ -310,17 +309,21 @@ CORS_ORIGIN_ALLOW_ALL = True
 JWT_EXPIRATION_DELTA = timedelta(hours=48)
 JWT_ALGORITHM = 'HS256'
 
-LOGIN_REDIRECT_TARGETS = {
-    'opensubs': {
-        'parent_location_href': 'http://localhost:9000/',
-        'redirect_to_url': 'http://localhost:9000/#/login/',
-    }
-}
+# called after the user authenticated from the frontend app. The auth token aill be appended at the end.
+OPENSUBS_LOGIN_URL = 'https://localhost:9000/#/login/'
+# called after the user authenticated from facebook canvas. The auth token will be appended at the end. When this is called you are inside the facebook canvas app iframe.
+OPENSUBS_FACEBOOK_CANVAS_LOGIN_URL = 'https://localhost:9000/#/facebook/login/'
+# called from inside the canvas iframe - should display the splash screen for facebook canvas
+OPENSUBS_FACEBOOK_CANVAS_SPLASH_URL = 'https://localhost:9000/#/facebook/splash'
+# should be set in local_settings: the url to the facebook app page e.g. https://apps.facebook.com/opensubs/
+OPENSUBS_FACEBOOK_CANVAS_APP_URL = ''
 
 # if you add a local_settings.py file, it will override settings here
 # but please, don't commit it to git.
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 try:
     from local_settings import *
+    if 'EXTRA_INSTALLED_APPS' in globals():
+        INSTALLED_APPS += EXTRA_INSTALLED_APPS
 except ImportError:
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ sauceclient
 django-sslify>=0.2.0
 django-cors-headers
 pyjwt
+django-sslserver

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,4 +51,3 @@ sauceclient
 django-sslify>=0.2.0
 django-cors-headers
 pyjwt
-django-sslserver

--- a/templates/user/login.html
+++ b/templates/user/login.html
@@ -34,10 +34,10 @@
                 <li>
                     <p><strong>{% trans "Enter using" %}</strong></p>
                     <p>
-                        <a class="btn" href="{% url 'social:begin' 'twitter' %}"{% if is_iframe %} target="_top"{% endif %} title="Twitter"><i class="fa fa-lg fa-twitter"></i></a>
-                        <a class="btn" href="{% url 'social:begin' 'google-oauth' %}"{% if is_iframe %} target="_top"{% endif %} title="Google"><i class="fa fa-lg fa-google-plus"></i></a>
-                        <a class="btn" href="{% url 'social:begin' 'facebook' %}"{% if is_iframe %} target="_top"{% endif %} title="Facebook"><i class="fa fa-lg fa-facebook"></i></a>
-                        <a class="btn" href="{% url 'social:begin' 'github' %}"{% if is_iframe %} target="_top"{% endif %} title="GitHub"><i class="fa fa-lg fa-github"></i></a>
+                        <a class="btn" href="{% url 'social:begin' 'twitter' %}?next={{next}}"{% if is_iframe %} target="_top"{% endif %} title="Twitter"><i class="fa fa-lg fa-twitter"></i></a>
+                        <a class="btn" href="{% url 'social:begin' 'google-oauth' %}?next={{next}}"{% if is_iframe %} target="_top"{% endif %} title="Google"><i class="fa fa-lg fa-google-plus"></i></a>
+                        <a class="btn" href="{% url 'social:begin' 'facebook' %}?next={{next}}"{% if is_iframe %} target="_top"{% endif %} title="Facebook"><i class="fa fa-lg fa-facebook"></i></a>
+                        <a class="btn" href="{% url 'social:begin' 'github' %}?next={{next}}"{% if is_iframe %} target="_top"{% endif %} title="GitHub"><i class="fa fa-lg fa-github"></i></a>
                     </p>
                 </li>
                 <li>

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url, patterns, include
-from views import PublicUserProfile, ProfileListView, login_view, login_redirect
+from views import PublicUserProfile, ProfileListView, login_view, login_redirect, login_redirect_facebook_canvas, login_redirect_facebook_canvas_complete, login_redirect_facebook_canvas_start
 
 profile_list = ProfileListView.as_view()
 user_public_profile = PublicUserProfile.as_view(
@@ -44,6 +44,9 @@ urlpatterns += patterns(
     url(r'^login/$', login_view,
         {'template_name': 'user/login.html'}, name='login'),
     url(r'^login-redirect/(?P<target>[0-9A-Za-z]+)/$', login_redirect),
+    url(r'^login-redirect-facebook-canvas/(?P<target>[0-9A-Za-z]+)/$', login_redirect_facebook_canvas),
+    url(r'^login-redirect-facebook-canvas-start/(?P<target>[0-9A-Za-z]+)/$', login_redirect_facebook_canvas_start),
+    url(r'^login-redirect-facebook-canvas-complete/(?P<target>[0-9A-Za-z]+)/$', login_redirect_facebook_canvas_complete),
     (r'^registration/', include('accounts.urls')),
     url(r'^(?P<pk>\d+)/$', user_public_profile, name='public-profile'),
     url(r'^(?P<pk>\d+)/topic/$', user_followed_topics,


### PR DESCRIPTION
Support for integrating a frontend canvas app with the Open Knesset facebook login process.

The process is as follows:
* The facebook app has an iframe which points to https://oknesset.org/users/login-redirect-facebook-canvas/(APP_NAME)
* If the user is authenticated - he will be redirected to relevant authentication page in the frontend site
* Otherwise - he will be redirect to a splash screen on the frontend site - with an indication that he came from facebook
* In the frontend site - when he needs to login, the frontend site redirects the user to https://oknesset.org/users/login-redirect-facebook-canvas-start/(APP_NAME)
* This starts the social auth for facebook - when done, the user will be redirected back to the frontend site with the authentication details.

Added an option to add INSTALLED_APPS from local_settings (EXTRA_INSTALLED_APPS) - this is to support running a local dev server using https - which is required by facebook