### PR TITLE
support running the local dev server on https

### DIFF
--- a/knesset/settings.py
+++ b/knesset/settings.py
@@ -155,6 +155,7 @@ INSTALLED_APPS = (
     'crispy_forms',
     'storages',
     'corsheaders',
+    'sslserver',
     #'knesset',
     'auxiliary',                  # knesset apps
     'mks',

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ sauceclient
 django-sslify>=0.2.0
 django-cors-headers
 pyjwt
+django-sslserver


### PR DESCRIPTION
this is required for facebook - when using the Open-Subs canvas app