### PR TITLE
lobbyists changes - added model for tracking changes and viewing via admin/api

### DIFF
--- a/apis/resources/__init__.py
+++ b/apis/resources/__init__.py
@@ -13,6 +13,7 @@ from auxiliary.api import PostResource, TagResource
 from events.api import EventResource
 from polyorg.api import CandidateListResource
 from persons.api import PersonResource
+from lobbyists.api import LobbyistsChangeResource, LobbyistResource, LobbyistCorporationResource
 
 v2_api = Api(api_name='v2')
 
@@ -35,3 +36,6 @@ v2_api.register(TagResource())
 v2_api.register(EventResource())
 v2_api.register(CandidateListResource())
 v2_api.register(PersonResource())
+v2_api.register(LobbyistsChangeResource())
+v2_api.register(LobbyistResource())
+v2_api.register(LobbyistCorporationResource())

--- a/lobbyists/admin.py
+++ b/lobbyists/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from models import Lobbyist, LobbyistCorporation
+from models import Lobbyist, LobbyistCorporation, LobbyistsChange
 from django.contrib.contenttypes import generic
 from links.models import Link
 
@@ -22,6 +22,10 @@ class LobbyistCorporationAdmin(admin.ModelAdmin):
     inlines = (LinksInline,)
 
 
+class LobbyistsChangeAdmin(admin.ModelAdmin):
+    list_display = ('date', 'type', 'content_type', 'object_id', 'content_object')
+
+
 admin.site.register(Lobbyist, LobbyistAdmin)
 admin.site.register(LobbyistCorporation, LobbyistCorporationAdmin)
-
+admin.site.register(LobbyistsChange, LobbyistsChangeAdmin)

--- a/lobbyists/api.py
+++ b/lobbyists/api.py
@@ -1,0 +1,31 @@
+from tastypie.contrib.contenttypes.fields import GenericForeignKeyField
+from tastypie.fields import ToOneField, DictField
+from apis.resources.base import BaseResource
+from models import LobbyistsChange, Lobbyist, LobbyistCorporation
+from persons.api import PersonResource
+
+
+class LobbyistResource(BaseResource):
+    person = ToOneField(PersonResource, 'person')
+    data = DictField('cached_data')
+
+    class Meta(BaseResource.Meta):
+        queryset = Lobbyist.objects.all()
+
+
+class LobbyistCorporationResource(BaseResource):
+    data = DictField('cached_data')
+
+    class Meta(BaseResource.Meta):
+        queryset = LobbyistCorporation.objects.all()
+
+
+class LobbyistsChangeResource(BaseResource):
+    content_object = GenericForeignKeyField({
+        Lobbyist: LobbyistResource,
+        LobbyistCorporation: LobbyistCorporationResource
+    }, 'content_object')
+
+    class Meta(BaseResource.Meta):
+        queryset = LobbyistsChange.objects.all()
+        allowed_methods = ['get']

--- a/lobbyists/migrations/0007_auto__add_lobbyistschange.py
+++ b/lobbyists/migrations/0007_auto__add_lobbyistschange.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'LobbyistsChange'
+        db.create_table(u'lobbyists_lobbyistschange', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('date', self.gf('django.db.models.fields.DateField')()),
+            ('type', self.gf('django.db.models.fields.CharField')(max_length=20)),
+            ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'])),
+            ('object_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
+            ('extra_data', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),
+        ))
+        db.send_create_signal(u'lobbyists', ['LobbyistsChange'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'LobbyistsChange'
+        db.delete_table(u'lobbyists_lobbyistschange')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'lobbyists.lobbyist': {
+            'Meta': {'object_name': 'Lobbyist'},
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'large_image_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'lobbyist'", 'null': 'True', 'to': u"orm['persons.Person']"}),
+            'source_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyistcorporation': {
+            'Meta': {'object_name': 'LobbyistCorporation'},
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'source_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyistcorporationalias': {
+            'Meta': {'object_name': 'LobbyistCorporationAlias'},
+            'alias_corporation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'lobbyistcorporationalias_alias'", 'unique': 'True', 'to': u"orm['lobbyists.LobbyistCorporation']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'main_corporation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'lobbyistcorporationalias_main'", 'to': u"orm['lobbyists.LobbyistCorporation']"})
+        },
+        u'lobbyists.lobbyistcorporationdata': {
+            'Meta': {'object_name': 'LobbyistCorporationData'},
+            'corporation': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'data'", 'null': 'True', 'to': u"orm['lobbyists.LobbyistCorporation']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lobbyists': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['lobbyists.Lobbyist']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'scrape_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'source_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyistdata': {
+            'Meta': {'object_name': 'LobbyistData'},
+            'corporation_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'corporation_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'faction_member': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'faction_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'family_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lobbyist': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'data'", 'null': 'True', 'to': u"orm['lobbyists.Lobbyist']"}),
+            'permit_type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'profession': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'represents': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['lobbyists.LobbyistRepresent']", 'symmetrical': 'False'}),
+            'scrape_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'source_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyisthistory': {
+            'Meta': {'object_name': 'LobbyistHistory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lobbyists': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'histories'", 'symmetrical': 'False', 'to': u"orm['lobbyists.Lobbyist']"}),
+            'scrape_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyistrepresent': {
+            'Meta': {'object_name': 'LobbyistRepresent'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'source_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyistrepresentdata': {
+            'Meta': {'object_name': 'LobbyistRepresentData'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lobbyist_represent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'data'", 'null': 'True', 'to': u"orm['lobbyists.LobbyistRepresent']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'scrape_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'source_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'})
+        },
+        u'lobbyists.lobbyistschange': {
+            'Meta': {'object_name': 'LobbyistsChange'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'extra_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'mks.knesset': {
+            'Meta': {'object_name': 'Knesset'},
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'number': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'mks.member': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Member'},
+            'area_of_residence': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'average_monthly_committee_presence': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'average_weekly_presence_hours': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'backlinks_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'bills_stats_approved': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'bills_stats_first': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'bills_stats_pre': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'bills_stats_proposed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'blog': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['planet.Blog']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'current_party': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'members'", 'null': 'True', 'to': u"orm['mks.Party']"}),
+            'current_position': ('django.db.models.fields.PositiveIntegerField', [], {'default': '999', 'blank': 'True'}),
+            'current_role_descriptions': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'date_of_birth': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_of_death': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'family_status': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'gender': ('django.db.models.fields.CharField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'img_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'is_current': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'number_of_children': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'parties': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'all_members'", 'symmetrical': 'False', 'through': u"orm['mks.Membership']", 'to': u"orm['mks.Party']"}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'place_of_birth': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'place_of_residence': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'place_of_residence_lat': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'place_of_residence_lon': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'residence_centrality': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'residence_economy': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'year_of_aliyah': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'mks.membership': {
+            'Meta': {'object_name': 'Membership'},
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'member': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mks.Member']"}),
+            'party': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mks.Party']"}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'default': '999', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'mks.party': {
+            'Meta': {'ordering': "('-number_of_seats',)", 'unique_together': "(('knesset', 'name'),)", 'object_name': 'Party'},
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_coalition': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'knesset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'parties'", 'null': 'True', 'to': u"orm['mks.Knesset']"}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'number_of_members': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'number_of_seats': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'split_from': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['mks.Party']", 'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'persons.person': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Person'},
+            'area_of_residence': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'calendar_sync_token': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'calendar_url': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'date_of_birth': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_of_death': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'family_status': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'gender': ('django.db.models.fields.CharField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'img_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'mk': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'person'", 'null': 'True', 'to': u"orm['mks.Member']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'number_of_children': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'place_of_birth': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'place_of_residence': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'place_of_residence_lat': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'place_of_residence_lon': ('django.db.models.fields.CharField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'residence_centrality': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'residence_economy': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'titles': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'persons'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['persons.Title']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'year_of_aliyah': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'persons.title': {
+            'Meta': {'object_name': 'Title'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        u'planet.blog': {
+            'Meta': {'ordering': "('title', 'url')", 'object_name': 'Blog'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '1024', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['lobbyists']

--- a/lobbyists/models.py
+++ b/lobbyists/models.py
@@ -4,6 +4,10 @@ from django.db import models
 from django.core.cache import cache
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes import generic
+import json
+
 
 class LobbyistHistoryManager(models.Manager):
 
@@ -299,3 +303,24 @@ class LobbyistRepresentData(models.Model):
     name = models.CharField(blank=True, null=True, max_length=100)
     domain = models.CharField(blank=True, null=True, max_length=100)
     type = models.CharField(blank=True, null=True, max_length=100)
+
+
+class LobbyistsChange(models.Model):
+    """
+    this model records the changes in lobbyist data
+    """
+    date = models.DateField()
+    type = models.CharField(max_length=20, choices=(
+        ('added', 'Added'),
+        ('deleted', 'Deleted'),
+        ('modified', 'Modified'),
+    ))
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    # this field contains a json dumps of the change diff
+    # relevant only for modified type
+    extra_data = models.TextField(null=True, blank=True)
+
+    def __unicode__(self):
+        return u'Lobbyists Change: {date} - {content_type} - {object} - {type}'.format(date=self.date, content_type=self.content_type, object=self.content_object, type=self.type)

--- a/lobbyists/scrapers/__init__.py
+++ b/lobbyists/scrapers/__init__.py
@@ -3,12 +3,13 @@
 from okscraper.base import BaseScraper
 from okscraper.sources import ScraperSource
 from okscraper.storages import ListStorage
-from lobbyists.models import LobbyistHistory, LobbyistCorporation, LobbyistCorporationData, Lobbyist
+from lobbyists.models import LobbyistHistory, LobbyistCorporation, LobbyistCorporationData, Lobbyist, LobbyistsChange, LobbyistData
 from django.core.exceptions import ObjectDoesNotExist
 from datetime import datetime
 from lobbyist import LobbyistScraper
 from lobbyists_index import LobbyistsIndexScraper
 from lobbyists_committeemeetings import *
+import json
 
 class MainScraperListStorage(ListStorage):
     """
@@ -63,8 +64,6 @@ class MainScraperListStorage(ListStorage):
                 corporation_data.save()
                 corporation.data.add(corporation_data)
                 corporation.save()
-
-        
         
     def commit(self):
         super(MainScraperListStorage, self).commit()
@@ -93,6 +92,88 @@ class MainScraper(BaseScraper):
         self.source = ScraperSource(LobbyistsIndexScraper())
         self.storage = MainScraperListStorage()
 
+    def _update_lobbyists_changes(self):
+        chgs = []
+
+        self._getLogger().info('processing lobbyist changes - deleting all existing changes and re-creating from scratch')
+        LobbyistsChange.objects.all().delete()
+
+        self._getLogger().info('lobbyist history (added / deleted lobbyists)')
+        prev_lh = None
+        for lh in LobbyistHistory.objects.order_by('scrape_time'):
+            # look for added / deleted lobbyyists
+            if prev_lh == None:
+                self._getLogger().debug(lh.scrape_time)
+                self._getLogger().debug('first history - all lobbyists considered as added')
+                added_lobbyist_ids = [l.pk for l in lh.lobbyists.all()]
+                deleted_lobbyist_ids = []
+            else:
+                prev_lobbyist_ids = set([l.pk for l in prev_lh.lobbyists.all()])
+                cur_lobbyist_ids = set([l.pk for l in lh.lobbyists.all()])
+                deleted_lobbyist_ids = list(prev_lobbyist_ids.difference(cur_lobbyist_ids))
+                added_lobbyist_ids = list(cur_lobbyist_ids.difference(prev_lobbyist_ids))
+                if len(deleted_lobbyist_ids) > 0 or len(added_lobbyist_ids) > 0:
+                    self._getLogger().debug(lh.scrape_time)
+                    self._getLogger().debug('%s deleted lobbyists, %s added lobbyists'%(len(deleted_lobbyist_ids), len(added_lobbyist_ids)))
+
+            for lid in added_lobbyist_ids: chgs.append(LobbyistsChange(date=lh.scrape_time, content_object=Lobbyist.objects.get(pk=lid), type='added'))
+            for lid in deleted_lobbyist_ids: chgs.append(LobbyistsChange(date=lh.scrape_time, content_object=Lobbyist.objects.get(pk=lid), type='deleted'))
+            prev_lh = lh
+
+        self._getLogger().info('lobbyist data (lobbyist metadata changes)')
+        lds = {}
+        for ld in LobbyistData.objects.order_by('scrape_time'):
+            lid = ld.lobbyist.pk
+            if lid in lds:
+                # we don't add an event for new lobbyist data, assuming you will get a lobbyist added event from the lobbyist history
+                changeset = []
+                prev_ld = lds[lid]
+                # looking for changes in the lobbyist data fields
+                for field in ['source_id', 'first_name', 'family_name', 'profession', 'corporation_name', 'corporation_id', 'faction_member', 'faction_name', 'permit_type']:
+                    if getattr(prev_ld, field) != getattr(ld, field):
+                        changeset.append((field, getattr(prev_ld, field), getattr(ld, field)))
+                # looking for changes in the lobbyist represents
+                # we use only the name because there are some problems with the other represents fields
+                prev_represents = set([r.name for r in prev_ld.represents.all()])
+                cur_represents = set([r.name for r in ld.represents.all()])
+                deleted_represent_names = list(prev_represents.difference(cur_represents))
+                if len(deleted_represent_names) > 0: changeset.append(('represent_names', 'deleted', deleted_represent_names))
+                added_represent_names = list(cur_represents.difference(prev_represents))
+                if len(added_represent_names) > 0: changeset.append(('represent_names', 'added', added_represent_names))
+                if len(changeset) > 0:
+                    self._getLogger().debug('%s: got %s changes'%(ld.scrape_time, len(changeset)))
+                    chgs.append(LobbyistsChange(date=ld.scrape_time, content_object=ld.lobbyist, type='modified', extra_data=json.dumps(changeset)))
+            lds[lid] = ld
+
+        self._getLogger().info('lobbyist corporation data')
+        lcds = {}
+        for lcd in LobbyistCorporationData.objects.order_by('scrape_time'):
+            lc = lcd.corporation
+            lcid = lc.pk
+            if lcid in lcds:
+                # existing corporation - need to check for changes
+                changeset = []
+                prev_lcd = lcds[lcid]
+                for field in ['name', 'source_id']:
+                    if getattr(prev_lcd, field) != getattr(lcd, field):
+                        changeset.append((field, getattr(prev_lcd, field), getattr(lcd, field)))
+                prev_lobbyists = set([l.pk for l in prev_lcd.lobbyists.all()])
+                cur_lobbyists = set([l.pk for l in lcd.lobbyists.all()])
+                deleted_lobbyists = list(prev_lobbyists.difference(cur_lobbyists))
+                if len(deleted_lobbyists) > 0: changeset.append(('lobbyists', 'deleted', deleted_lobbyists))
+                added_lobbyists = list(cur_lobbyists.difference(prev_lobbyists))
+                if len(added_lobbyists) > 0: changeset.append(('lobbyists', 'added', added_lobbyists))
+                if len(changeset) > 0:
+                    self._getLogger().debug('%s: got %s changes'%(lcd.scrape_time, len(changeset)))
+                    chgs.append(LobbyistsChange(date=lcd.scrape_time, content_object=lc, type='modified', extra_data=json.dumps(changeset)))
+            else:
+                # new coropration
+                chgs.append(LobbyistsChange(date=lcd.scrape_time, content_object=lc, type='added'))
+            lcds[lcid] = lcd
+
+        self._getLogger().info('bulk creating %s changes'%len(chgs))
+        LobbyistsChange.objects.bulk_create(chgs)
+
     def _scrape(self):
         lobbyist_ids = self.source.fetch()
         i=0
@@ -104,5 +185,4 @@ class MainScraper(BaseScraper):
         self._getLogger().info('looking for mentions of lobbyists in committee meetings')
         LobbyistsCommiteeMeetingsScraper().scrape()
         LobbyistCorporationsCommitteeMeetingsScraper().scrape()
-
-
+        self._update_lobbyists_changes()


### PR DESCRIPTION
As part of #231  - this PR adds a LobbyistsChange model which records the changes in lobbyist data over time.

It also includes a django admin view to browse this data and some api resources.

The main goal of this PR is to be able to see what data we have and then decide how to display it.

The LobbyistsChange model is populated during the existing lobbyists scraping process.

<!---
@huboard:{"order":333.0,"milestone_order":333,"custom_state":""}
-->
