### PR TITLE
169 add link from vote to relevant part in plenum protocol

### DIFF
--- a/plenum/management/commands/parse_plenum_protocols_subcommands/download.py
+++ b/plenum/management/commands/parse_plenum_protocols_subcommands/download.py
@@ -117,3 +117,11 @@ def Download(verbosity_level,redownload):
     _downloadLatest(False,redownload)
     _downloadLatest(True,redownload)
 
+def download_for_existing_meeting(meeting):
+    DATA_ROOT = getattr(settings, 'DATA_ROOT')
+    _copy(meeting.src_url, DATA_ROOT+'plenum_protocols/tmp')
+    xmlData = _antiword(DATA_ROOT+'plenum_protocols/tmp')
+    os.remove(DATA_ROOT+'plenum_protocols/tmp')
+    meeting.protocol_text=xmlData
+    meeting.save()
+

--- a/plenum/management/commands/parse_plenum_protocols_subcommands/parse.py
+++ b/plenum/management/commands/parse_plenum_protocols_subcommands/parse.py
@@ -29,4 +29,4 @@ def Parse(verbosity_level,reparse, meeting_pks=None):
         meeting.create_protocol_parts(delete_existing=reparse,mks=mks,mk_names=mk_names)
 
 def parse_for_existing_meeting(meeting):
-    Parse(3, True, [meeting.pk])
+    Parse(1, True, [meeting.pk])

--- a/plenum/management/commands/parse_plenum_protocols_subcommands/parse.py
+++ b/plenum/management/commands/parse_plenum_protocols_subcommands/parse.py
@@ -9,12 +9,15 @@ from plenum import create_protocol_parts
 
 verbosity=1
 
-def Parse(verbosity_level,reparse):
+def Parse(verbosity_level,reparse, meeting_pks=None):
     global verbosity
     verbosity=int(verbosity_level)
     #DATA_ROOT = getattr(settings, 'DATA_ROOT')
-    plenum=Committee.objects.filter(type='plenum')[0]
-    meetings=CommitteeMeeting.objects.filter(committee=plenum).exclude(protocol_text='')
+    if meeting_pks is not None:
+        meetings = CommitteeMeeting.objects.filter(pk__in=meeting_pks)
+    else:
+        plenum=Committee.objects.filter(type='plenum')[0]
+        meetings=CommitteeMeeting.objects.filter(committee=plenum).exclude(protocol_text='')
     if not reparse:
         meetings=meetings.annotate(Count('parts')).filter(parts__count=0)
     if verbosity>1:
@@ -24,3 +27,6 @@ def Parse(verbosity_level,reparse):
     (mks,mk_names)=create_protocol_parts.get_all_mk_names()
     for meeting in meetings:
         meeting.create_protocol_parts(delete_existing=reparse,mks=mks,mk_names=mk_names)
+
+def parse_for_existing_meeting(meeting):
+    Parse(3, True, [meeting.pk])

--- a/plenum/management/commands/plenum_link_votes.py
+++ b/plenum/management/commands/plenum_link_votes.py
@@ -1,0 +1,31 @@
+# encoding: utf-8
+
+from django.core.management.base import NoArgsCommand
+from optparse import make_option
+from committees.models import Committee
+from datetime import datetime, timedelta
+
+
+class Command(NoArgsCommand):
+
+    option_list = NoArgsCommand.option_list + (
+        make_option('--all',action='store_true',dest='all',
+            help="process all plenum protocols (instead of just the latest)"),
+        make_option('--reparse',action='store_true',dest='reparse',
+            help="also redownload and reparse the protocol text")
+    )
+
+    latest_days = 30
+
+    def handle_noargs(self, **options):
+        plenum = Committee.objects.get(name='Plenum')
+        if options.get('all', False):
+            qs = plenum.meetings.all()
+        else:
+            qs = plenum.meetings.filter(date__gte=datetime.now()-timedelta(days=self.latest_days))
+        for meeting in qs:
+            if int(options.get('verbosity', '1')) > 1:
+                print 'meeting %s'%meeting.pk
+            if options.get('reparse', False):
+                meeting.reparse_plenum_protocol()
+            meeting.plenum_link_votes()

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ django-sslify>=0.2.0
 django-cors-headers
 pyjwt
 django-sslserver
+python-hebrew-numbers==0.1.0


### PR DESCRIPTION
fixes #169 

added a management command - plenum_link_votes - by default runs on plenum meetings form last 30 days. Can pass --all to run on all plenums.

#### Deployment
* run: ./manage.py plenum_link_votes --all -v2
* add a cronjob (once a day): ./manage.py plenum_link_votes