### PR TITLE
add interface for editing tag synonyms

### DIFF
--- a/auxiliary/admin.py
+++ b/auxiliary/admin.py
@@ -1,7 +1,14 @@
+# -*- coding: utf-8 -*-
+
 from django.contrib import admin
 
-from .models import Tidbit, TagSuggestion, TagSynonym, TagKeyphrase
+from .models import Tidbit, TagSuggestion, TagSynonym, TagKeyphrase, Tag
 from auxiliary.tag_suggestions import approve as tag_suggestions_approve
+from tagging.admin import TagAdmin as OriginalTagAdmin
+from tagging.forms import TagAdminForm as OriginalTagAdminForm
+from django.contrib.admin import SimpleListFilter
+from django.utils.translation import ugettext_lazy as _
+from django.utils.html import escape, escapejs
 
 
 class TidibitAdmin(admin.ModelAdmin):
@@ -36,3 +43,53 @@ class TagKeyphraseAdmin(admin.ModelAdmin):
     model = TagKeyphrase
 
 admin.site.register(TagKeyphrase, TagKeyphraseAdmin)
+
+
+class TagSynonymInline(admin.TabularInline):
+    model = TagSynonym
+    fk_name = 'tag'
+
+
+class TagTagSynonymListFilter(SimpleListFilter):
+    title = _('Tag Synonym')
+    parameter_name = 'synonyms'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('parents', _('parent tags'),),
+            ('synonyms', _('synonym tags'),),
+            ('parentswithsynonyms', _('parent tags with synonyms')),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == 'parents':
+            return queryset.filter(synonym_synonym_tag=None)
+        elif self.value() ==  'synonyms':
+            return queryset.exclude(synonym_synonym_tag=None)
+        elif self.value() == 'parentswithsynonyms':
+            return queryset.filter(synonym_synonym_tag=None).exclude(synonym_proper_tag=None)
+        else:
+            return queryset
+
+
+class TagAdmin(admin.ModelAdmin):
+    model=Tag
+    inlines = (TagSynonymInline,)
+    list_filter = (TagTagSynonymListFilter,)
+    list_display = ('name', 'synonyms',)
+
+    def synonyms(self, tag):
+        synonyms = []
+        if tag.synonym_synonym_tag.count() == 0:
+            #  parent tag
+            synonyms = [escape(synonym) for synonym in tag.synonym_proper_tag.values_list('synonym_tag__name', flat=True)]
+        synonyms.append(u'<span class="tag_synonym_msg"></span><a href="javascript:tag_admin.tag_synonym_click(%s, \'%s\');" class="tag_synonym_action">( הוספת תג נרדף )</a><a href="javascript:tag_admin.tag_synonym_secondary_click(%s);" class="tag_synonym_secondary_action"></a>'%(tag.pk,escapejs(tag), tag.pk,))
+        return ', '.join(synonyms)
+    synonyms.allow_tags = True
+
+    class Media:
+        js = ('js/admin/tag_admin.js',)
+
+
+admin.site.unregister(Tag)
+admin.site.register(Tag, TagAdmin)

--- a/auxiliary/views.py
+++ b/auxiliary/views.py
@@ -411,6 +411,16 @@ def create_tag_and_add_to_item(request, app, object_type, object_id):
         return HttpResponseNotAllowed(['POST'])
 
 
+@permission_required('tagging.add_tag')
+def add_tag_synonym(request, parent_tag_id, synonym_tag_id):
+    parent_tag = Tag.objects.get(pk=parent_tag_id)
+    synonym_tag = Tag.objects.get(pk=synonym_tag_id)
+    assert parent_tag.synonym_synonym_tag.count() == 0
+    assert synonym_tag != parent_tag
+    TagSynonym.objects.create(tag_id = parent_tag_id, synonym_tag_id=synonym_tag_id)
+    return HttpResponse('ok')
+
+
 def calculate_cloud_from_models(*args):
     from tagging.models import Tag
     cloud = Tag._default_manager.cloud_for_model(args[0])

--- a/knesset/urls.py
+++ b/knesset/urls.py
@@ -29,7 +29,7 @@ from auxiliary.views import (
     main, post_annotation, post_details, post_feedback,
     RobotsView, AboutView, CommentsView, add_tag_to_object,
     remove_tag_from_object, create_tag_and_add_to_item, help_page,
-    TagList, TagDetail, suggest_tag_post, untagged_objects)
+    TagList, TagDetail, suggest_tag_post, untagged_objects, add_tag_synonym)
 
 admin.autodiscover()
 
@@ -85,6 +85,7 @@ urlpatterns = patterns('',
     # disabled for now, because we don't want users to add more tags.
     # will be added back in the future, but for editors only.
     #url(r'^tags/(?P<app>\w+)/(?P<object_type>\w+)/(?P<object_id>\d+)/create-tag/$', create_tag_and_add_to_item, name='create-tag'),
+    url(r'^add_tag_synonym/(?P<parent_tag_id>\d+)/(?P<synonym_tag_id>\d+)/$', add_tag_synonym),
     url(r'^tags/$', TagList.as_view(), name='tags-list'),
     url(r'^tags/(?P<slug>.*)/$', TagDetail.as_view(), name='tag-detail'),
     url(r'^suggest-tag-post/$', suggest_tag_post, name='suggest-tag-post'),

--- a/static/js/admin/tag_admin.js
+++ b/static/js/admin/tag_admin.js
@@ -1,0 +1,54 @@
+tag_admin = {
+
+    _set_action: function(html, secondary_html, msg) {
+        $('.tag_synonym_action').html(html);
+        $('.tag_synonym_secondary_action').html(secondary_html);
+        $('.tag_synonym_msg').html(msg);
+    },
+
+    _waitFor$: function(callback) {
+        if ($) {
+            callback();
+        } else {
+            setTimeout(function() {
+                tag_admin._waitFor$(callback);
+            }, 5);
+        }
+    },
+
+    init: function() {
+        document.write('<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.0.min.js"></script>');
+        tag_admin._waitFor$(function() {
+            $(function() {
+                if (window.sessionStorage['choose_synonym_for']) {
+                    tag_admin._set_action('( סימון כתג נרדף )', ' | ( ביטול )', ' -- תגית אב: '+window.sessionStorage['parent_tag_name']+' -- ');
+                }
+            });
+        });
+    },
+
+    tag_synonym_click: function(tag_id, tag_name) {
+        if (window.sessionStorage['choose_synonym_for']) {
+            var parent_tag = window.sessionStorage['choose_synonym_for'];
+            var synonym_tag = tag_id;
+            this._set_action('( נא להמתין ... )', '', '');
+            $.get('/add_tag_synonym/'+parent_tag+'/'+synonym_tag+'/', function() {
+                //window.sessionStorage.clear();
+                //tag_admin._set_action('( add synonym )', '');
+                tag_admin._set_action('( סימון כתג נרדף )', ' | ( ביטול )', ' -- תגית אב: '+window.sessionStorage['parent_tag_name']+' -- בוצע -- ');
+            });
+        } else {
+            window.sessionStorage['choose_synonym_for'] = tag_id;
+            window.sessionStorage['parent_tag_name'] = tag_name;
+            this._set_action('( סימון כתג נרדף )', ' | ( ביטול )', ' -- תגית אב: '+window.sessionStorage['parent_tag_name']+' -- ');
+        }
+    },
+
+    tag_synonym_secondary_click: function(tag_id) {
+        window.sessionStorage.clear();
+        tag_admin._set_action('( הוספת תג נרדף )', '', '');
+    }
+
+};
+
+tag_admin.init();


### PR DESCRIPTION
fixes #202 

* content editors should have the tagging.add_tag permission + access to admin
* the mark of synonyms is done through tag admin - next to each tag there is a list of tag synonyms, and a link to add another
* when you click on this link - you can then search for the synonym tag and mark the synonym tag
* it's an ugly hack, but it works and allows content editors to mark tag synonyms which is important work..
