### PR TITLE
fix plenum protocol parsing management command

### DIFF
--- a/plenum/management/commands/parse_plenum_protocols_subcommands/download.py
+++ b/plenum/management/commands/parse_plenum_protocols_subcommands/download.py
@@ -25,13 +25,16 @@ def _get_committees_index_page(full):
         encoding='iso_8859_8'
     else:
         url=URL
-        encoding='utf8'
+        # encoding='utf8'
+        # the encoding of this page used to be utf-8 but looks like they reverted back to iso-8859-8
+        encoding='iso_8859_8'
     _debug('getting the html from '+url)
     try:
         return unicode(urllib2.urlopen(url).read(),encoding)
     except Exception, e:
         print 'could not fetch committees_index_page, exception: '+str(e)
         traceback.print_exc(file=sys.stdout)
+        return ''
 
 def _copy(url,to):
     #_debug("copying from "+url+" to "+to)
@@ -88,7 +91,11 @@ def _downloadLatest(full,redownload):
     aelts=soup('a',text=words_of_the_knesset)
     for aelt in aelts:
         selt=aelt.findPrevious('span',text=re.compile(DISCUSSIONS_ON_DATE))
-        url=FILE_BASE_URL+aelt.parent.get('href')
+        href = aelt.parent.get('href')
+        if href.startswith('http'):
+            url = href
+        else:
+            url=FILE_BASE_URL+href
         filename=re.search(r"[^/]*$",url).group()
         _debug(filename)
         m=re.search(r"\((.*)/(.*)/(.*)\)",selt)


### PR DESCRIPTION
knesset made some changes on their side

after deployment need to run the following management command (only once):

./manage.py parse_plenum_protocols --redownload --reparse -v3
