### PR TITLE
improve plenum scraping: add logging, ignore antiword failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ knesset/templates/last_build.txt
 media/avatars
 media/agendas
 data/committee_mms_videos
+/data/plenum_protocols

--- a/auxiliary/views.py
+++ b/auxiliary/views.py
@@ -18,6 +18,8 @@ from django.views.generic import TemplateView, DetailView, ListView
 from django.views.generic.list import BaseListView
 from django.views.decorators.http import require_http_methods
 from tagging.models import Tag, TaggedItem
+from django.utils import timezone
+from datetime import timedelta
 
 from .forms import TidbitSuggestionForm, FeedbackSuggestionForm, TagSuggestionForm
 from .models import Tidbit, TagSuggestion
@@ -91,7 +93,7 @@ class BaseTagMemberListView(ListView):
 
 
 class MainScraperStatusView(ListView):
-    queryset = ScraperRun.objects.all().order_by('-start_time')
+    queryset = ScraperRun.objects.all().filter(start_time__gt=timezone.now()-timedelta(days=30)).order_by('-start_time')
     template_name = 'auxiliary/main_scraper_status.html'
 
     def get_context_data(self, *args, **kwargs):

--- a/plenum/management/commands/parse_plenum_protocols.py
+++ b/plenum/management/commands/parse_plenum_protocols.py
@@ -1,13 +1,14 @@
 # encoding: utf-8
-
-from django.core.management.base import NoArgsCommand
 from optparse import make_option
 from plenum.management.commands.parse_plenum_protocols_subcommands.download import Download
 from plenum.management.commands.parse_plenum_protocols_subcommands.parse import Parse
+from okscraper_django.management.base_commands import NoArgsDbLogCommand
 
-class Command(NoArgsCommand):
 
-    option_list = NoArgsCommand.option_list + (
+class Command(NoArgsDbLogCommand):
+    BASE_LOGGER_NAME = 'open-knesset'
+
+    option_list = NoArgsDbLogCommand.option_list + (
         make_option('--download',action='store_true',dest='download',
             help="download the latest protocols from the knesset, convert them to xml and store in db"),
         make_option('--parse',action='store_true',dest='parse',
@@ -17,14 +18,14 @@ class Command(NoArgsCommand):
         make_option('--reparse',action='store_true',dest='reparse',
             help="like the parse stage but parses all the existing data again"),
     )
-
-    def handle_noargs(self, **options):
+    
+    def _handle_noargs(self, **options):
         didSomething=False
         if options.get('download',False) or options.get('redownload',False):
-            Download(options.get('verbosity',1),options.get('redownload',False))
+            Download(options.get('redownload',False), self._logger)
             didSomething=True
         if options.get('parse',False) or options.get('reparse',False):
-            Parse(options.get('verbosity',1),options.get('reparse',False))
+            Parse(options.get('reparse',False), self._logger)
             didSomething=True
         if not didSomething==True:
-            print 'invalid options, try --help for help'
+            self._log_error('invalid options, try --help for help')

--- a/plenum/management/commands/plenum_link_votes.py
+++ b/plenum/management/commands/plenum_link_votes.py
@@ -27,5 +27,5 @@ class Command(NoArgsCommand):
             if int(options.get('verbosity', '1')) > 1:
                 print 'meeting %s'%meeting.pk
             if options.get('reparse', False):
-                meeting.reparse_plenum_protocol()
+                meeting.reparse_protocol()
             meeting.plenum_link_votes()

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ django-crispy-forms==1.2.3
 django-storages==1.1.8
 boto==2.20.1
 BeautifulSoup4
-okscraper-django==0.0.8
+okscraper-django==0.0.9
 ujson
 selenium
 sauceclient

--- a/simple/management/commands/syncdata.py
+++ b/simple/management/commands/syncdata.py
@@ -25,8 +25,7 @@ import parse_presence, parse_laws, mk_roles_parser, parse_remote
 from parse_gov_legislation_comm import ParseGLC
 
 from syncdata_globals import p_explanation,strong_explanation,explanation
-from plenum.management.commands.parse_plenum_protocols_subcommands.download \
-    import _antiword
+from simple.management.utils import antiword
 
 ENCODING = 'utf8'
 
@@ -940,12 +939,14 @@ class Command(NoArgsCommand):
             return self.handle_doc_protocol(file_str)
 
     def handle_doc_protocol(self, file_str):
-        fname = DATA_ROOT + 'comm_p/comm_p.doc'
+        directory = os.path.join(DATA_ROOT, 'comm_p')
+        if not os.path.exists(directory): os.makedirs(directory)
+        fname = os.path.join(directory, 'comm_p.doc')
         f = open(fname, 'wb')
         file_str.seek(0)
         f.write(file_str.read())
         f.close()
-        x = _antiword(fname)
+        x = antiword(fname)
         return re.sub('[\n ]{2,}', '\n\n', re.sub('<.*?>','',x))
 
     def handle_rtf_protocol(self, file_str):

--- a/simple/management/utils.py
+++ b/simple/management/utils.py
@@ -1,0 +1,13 @@
+import os
+import subprocess
+
+def antiword(filename, logger=None):
+    cmd='antiword -x db '+filename+' > '+filename+'.awdb.xml'
+    if logger: logger.debug(cmd)
+    output = subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+    if logger: logger.debug(output)
+    with open(filename+'.awdb.xml','r') as f:
+        xmldata=f.read()
+    if logger: logger.debug('len(xmldata) = '+str(len(xmldata)))
+    os.remove(filename+'.awdb.xml')
+    return xmldata


### PR DESCRIPTION
fixes #379 - 

* if antiword does not detect a word file - it logs the error and problematic meeting is skipped (instead of raising exception as it did before)
* added better logging using the okscraper-django framework, now plenum parse process will be logged and it's output available at oknesset.org/scrapers
* limited oknesset.org/scrapers to only show last 30 days as page started getting too big