### PR TITLE
remove extraneous text: "//HASADNA PIWIK ANALYTICS"

### DIFF
--- a/templates/site_base.html
+++ b/templates/site_base.html
@@ -286,7 +286,6 @@
     {% endif %}
     </script>
 
-    //HASADNA PIWIK ANALYTICS
     <!-- Piwik -->
     <script type="text/javascript">
       var _paq = _paq || [];


### PR DESCRIPTION
removed extraneous text "//HASADNA PIWIK ANALYTICS" from bottom of page
<img width="1848" alt="screen shot 2015-12-14 at 10 43 01 pm" src="https://cloud.githubusercontent.com/assets/2941263/11793428/3521a624-a2b4-11e5-80b4-95df2e339b52.png">
