### PR TITLE
Adding a custom test runner, currently mainly using to disable debug …

### DIFF
--- a/knesset/browser_test_runner.py
+++ b/knesset/browser_test_runner.py
@@ -18,6 +18,7 @@ sauce_platforms = [
     {"platform": "Linux", "browserName": "firefox", "version": "29"}
 ]
 
+
 class Runner(DiscoverRunner):
     """
     The browser test runner modifies the following from the default django runner:
@@ -28,24 +29,24 @@ class Runner(DiscoverRunner):
 
     option_list = (
         make_option('-t', '--top-level-directory',
-            action='store', dest='top_level', default=None,
-            help='Top level of project for unittest discovery.'),
+                    action='store', dest='top_level', default=None,
+                    help='Top level of project for unittest discovery.'),
         make_option('-p', '--pattern', action='store', dest='pattern',
-            default="browser_cases*.py",
-            help='The test matching pattern. Defaults to browser_cases*.py.'),
+                    default="browser_cases*.py",
+                    help='The test matching pattern. Defaults to browser_cases*.py.'),
         make_option('--full-initialization', action='store_true', dest='fullinitialization',
-            default=False,
-            help='this should only be used when running ci - it initializes the environment from scratch'),
+                    default=False,
+                    help='this should only be used when running ci - it initializes the environment from scratch'),
         make_option('--sauce-user', action='store', dest='sauceuser',
-            default='',
-            help='SauceLabs username (required if browser=Sauce, see https://docs.saucelabs.com/reference/sauce-connect/#managing-multiple-tunnels)'),
+                    default='',
+                    help='SauceLabs username (required if browser=Sauce, see https://docs.saucelabs.com/reference/sauce-connect/#managing-multiple-tunnels)'),
         make_option('--sauce-accesskey', action='store', dest='sauceaccesskey',
-            default='',
-            help='SauceLabs access key (required if browser=Sauce)'),
+                    default='',
+                    help='SauceLabs access key (required if browser=Sauce)'),
         make_option('--browser', action='store', dest='browser',
-            default='Firefox',
-            help='The browser to use for selenium tests default is "Firefox", can also run remotely on sauce labs - see docs')
-        )
+                    default='Firefox',
+                    help='The browser to use for selenium tests default is "Firefox", can also run remotely on sauce labs - see docs')
+    )
 
     def __init__(self, *args, **kwargs):
         global browser, sauce_username, sauce_accesskey
@@ -71,7 +72,8 @@ class Runner(DiscoverRunner):
 
     def create_superuser(self):
         print('Creating test superuser (admin/123456)')
-        management.call_command('createsuperuser', interactive=False, username='admin', email='OpenKnessetAdmin@mailinator.com')
+        management.call_command('createsuperuser', interactive=False, username='admin',
+                                email='OpenKnessetAdmin@mailinator.com')
         command = changepassword.Command()
         command._get_pass = lambda *args: '123456'
         command.execute('admin')

--- a/knesset/common_test_runner.py
+++ b/knesset/common_test_runner.py
@@ -1,0 +1,11 @@
+import logging
+
+
+from django_nose import NoseTestSuiteRunner
+
+
+class KnessetTestRunner(NoseTestSuiteRunner):
+    def setup_test_environment(self, **kwargs):
+        # Disabling debug/info in testing
+        logging.disable(logging.WARNING)
+        return super(KnessetTestRunner, self).setup_test_environment(**kwargs)

--- a/knesset/settings.py
+++ b/knesset/settings.py
@@ -231,7 +231,7 @@ file_logger.addHandler(h)
 # Console loggers, Best practice always log to stdout and stderr and let third party environment to deal with logging
 # See 12 factor app http://12factor.net/logs
 # Todo refactor this to support stderr and out and more dynamic config supporting sentry etc
-console_logger = logging.getLogger('') #root logger
+console_logger = logging.getLogger('')  # root logger
 console_logger.setLevel(logging.WARNING)
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
 
@@ -277,7 +277,6 @@ HITCOUNT_KEEP_HIT_ACTIVE = {'hours': 1}
 HITCOUNT_HITS_PER_IP_LIMIT = 0
 HITCOUNT_EXCLUDE_USER_GROUP = ()
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = ['--with-xunit']
 
 SERIALIZATION_MODULES = {
@@ -343,6 +342,9 @@ KIKAR_BASE_URL = 'http://www.kikar.org'
 # if you add a local_settings.py file, it will override settings here
 # but please, don't commit it to git.
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
+TEST_RUNNER = 'knesset.common_test_runner.KnessetTestRunner'
+
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION

#### Change list
- Moving to a custom test runner (inherting from the current nose runner we use), elegant way to change global settings in testing if needed. currently solving the debug logging all over the place in tests