### PR TITLE
Hardcoded django-nose version to fix travis failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ django-avatar==2.0
 -e git://github.com/spreeker/django-voting2.git#egg=django-voting2
 django-debug-toolbar<1.4
 nose
-django-nose
+django-nose==1.4.3
 django-devserver==0.8.0
 ipython
 django-tinymce==1.5.2


### PR DESCRIPTION
Builds are failing since a minor django-nose version update is breaking imports (:( ) 
django-nose version wasn't specified in the requirements file, and now a working version is specified 

