### PR TITLE
hide or show committee topics by waffle flag

### DIFF
--- a/committees/tests/test_committee_detail_view.py
+++ b/committees/tests/test_committee_detail_view.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
+from waffle import testutils as waffle_testutils
 from tagging.models import Tag, TaggedItem
 from waffle import testutils as waffle_testutils
 
@@ -73,6 +74,7 @@ I have a deadline''')
         self.mk_1.delete()
         self.topic.delete()
 
+    @waffle_testutils.override_flag('show_committee_topics', active=True)
     def test_committee_list_view(self):
         res = self.client.get(reverse('committee-list'))
         self.assertEqual(res.status_code, 200)
@@ -82,6 +84,32 @@ I have a deadline''')
                          [self.committee_1.id, self.committee_2.id, ])
         self.assertQuerysetEqual(res.context['topics'],
                                  ["<Topic: hello>"])
+
+    @waffle_testutils.override_flag('show_committee_topics', active=False)
+    def test_committee_list_view_topics_are_hidden_when_flag_inactive(self):
+        res = self.client.get(reverse('committee-list'))
+        self.assertEqual(res.status_code, 200)
+        with self.assertRaises(KeyError, msg="'topics' key should not appear"
+                                             " in context, but exists."):
+            topics = res.context['topics']
+
+    @waffle_testutils.override_flag('show_committee_topics', active=True)
+    def test_committee_topics_is_displayed_when_flag_is_active(self):
+        res = self.client.get(self.committee_1.get_absolute_url())
+
+        self.assertEqual(res.status_code, 200)
+        topics = res.context['topics']
+        self.assertTrue(topics,
+                        msg="'topics' key should appear in context, but isn't")
+
+    @waffle_testutils.override_flag('show_committee_topics', active=False)
+    def test_committee_topics_is_hidden_when_flag_is_not_active(self):
+        res = self.client.get(self.committee_1.get_absolute_url())
+
+        self.assertEqual(res.status_code, 200)
+        with self.assertRaises(KeyError, msg="'topics' key should not appear"
+                                             " in context, but exists."):
+            topics = res.context['topics']
 
     def test_committee_returns_a_list_of_meetings(self):
         res = self.client.get(self.committee_1.get_absolute_url())

--- a/committees/views.py
+++ b/committees/views.py
@@ -56,11 +56,15 @@ class CommitteeListView(ListView):
         context = super(CommitteeListView, self).get_context_data(**kwargs)
         context['tags_cloud'] = Tag.objects.cloud_for_model(CommitteeMeeting)
         if waffle.flag_is_active(self.request, 'show_committee_topics'):
-            context["topics"] = Topic.objects.summary()[:self.INITIAL_TOPICS]
-            context["topics_more"] = \
-                Topic.objects.summary().count() > self.INITIAL_TOPICS
-            context["INITIAL_TOPICS"] = self.INITIAL_TOPICS
+            context = self._add_topics_to_context(context)
 
+        return context
+
+    def _add_topics_to_context(self, context):
+        context["topics"] = Topic.objects.summary()[:self.INITIAL_TOPICS]
+        context["topics_more"] = \
+            Topic.objects.summary().count() > self.INITIAL_TOPICS
+        context["INITIAL_TOPICS"] = self.INITIAL_TOPICS
         return context
 
 

--- a/less/google-search-results.less
+++ b/less/google-search-results.less
@@ -31,7 +31,7 @@
       .gsc-cursor-page { 
         font-size: 16px; text-decoration: none;
         border-color: @borderColor;
-        color: ;
+        color: black;
       }
   }
   

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -7967,7 +7967,7 @@ div.color_swatch {
   font-size: 16px;
   text-decoration: none;
   border-color: #e6e6e6;
-  color: ;
+  color: black;
 }
 #google-search-results .gcsc-branding,
 #google-search-results .gsc-results {

--- a/templates/committees/committee_detail.html
+++ b/templates/committees/committee_detail.html
@@ -40,15 +40,19 @@
 
     </script>
 {% endblock %}
-{% block description %}{{ object.name }} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
+{% block description %}{{ object.name }} -
+    {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
 
-{% block nav-committees %}{% ifnotequal object.type 'plenum' %}class="active"{% endifnotequal %}{% endblock %}
-{% block nav-plenum %}{% ifequal object.type 'plenum' %}class="active"{% endifequal %}{% endblock %}
+{% block nav-committees %}{% ifnotequal object.type 'plenum' %}class="active"
+{% endifnotequal %}{% endblock %}
+{% block nav-plenum %}{% ifequal object.type 'plenum' %}class="active"
+{% endifequal %}{% endblock %}
 
 
 {% block breadcrumbs %}
     {% ifnotequal object.type 'plenum' %}
-        <li><a href="{% url 'committee-list' %}">{% trans "Committees" %}</a> <span class="divider">/</span></li>
+        <li><a href="{% url 'committee-list' %}">{% trans "Committees" %}</a>
+            <span class="divider">/</span></li>
     {% endifnotequal %}
     <li class="active">{{ object }}</li>
 {% endblock %}
@@ -85,7 +89,9 @@
     <div class="row">
         <div class="cards span8">
             <section class="card card-list">
-                <header><h2><i class="fa fa-calendar"></i>{% trans 'Future Meetings' %}</h2></header>
+                <header><h2><i
+                        class="fa fa-calendar"></i>{% trans 'Future Meetings' %}
+                </h2></header>
                 <ul>
 
                     <!-- Note that the difference is sorting is not a mistake, the more interesting future meetings for
@@ -96,7 +102,9 @@
                         <li>{% trans "None" %}</li>
                     {% endfor %}
                     {% if more_future_meetings_available %}
-                        <li><a href="all_future_meetings/">{% trans 'more...' %}</a></li>
+                        <li>
+                            <a href="all_future_meetings/">{% trans 'more...' %}</a>
+                        </li>
                     {% endif %}
                 </ul>
             </section>
@@ -112,7 +120,9 @@
                             <li>{% trans "None" %}</li>
                         {% endfor %}
                         {% if more_unpublished_available %}
-                            <li><a href="all_unpublished_protocols/">{% trans 'more...' %}</a></li>
+                            <li>
+                                <a href="all_unpublished_protocols/">{% trans 'more...' %}</a>
+                            </li>
                         {% else %}
                             <li>{% include "_feature_unavailable_message.html" %}</li>
                         {% endif %}
@@ -120,8 +130,12 @@
                 </ul>
             </section>
             <section class="card card-list card-list-latest">
-                <header><h2><i class="fa fa-clock-o"></i>{% trans 'Last Meetings' %}</h2></header>
-                <div id="unpublished-protocols" class="alert alert-info"><span class="num-unpublished">{{ protocol_not_yet_published_list|length }}</span> {% trans 'Unpublished Protocols' %}</div>
+                <header><h2><i
+                        class="fa fa-clock-o"></i>{% trans 'Last Meetings' %}
+                </h2></header>
+                <div id="unpublished-protocols" class="alert alert-info"><span
+                        class="num-unpublished">{{ protocol_not_yet_published_list|length }}</span> {% trans 'Unpublished Protocols' %}
+                </div>
                 <ul>
                     {% for o in meetings_list|dictsortreversed:"date" %}
                         {% include "committees/_meeting_li.html" with add_li=1 %}
@@ -129,11 +143,13 @@
                         <li>{% trans "None" %}</li>
                     {% endfor %}
                     {% if more_meetings_available %}
-                        <li><a href="all_meetings/">{% trans 'more...' %}</a></li>
+                        <li><a href="all_meetings/">{% trans 'more...' %}</a>
+                        </li>
                     {% endif %}
                 </ul>
             </section>
-            <section class="card card-list card-list-latest" id="kikar-statuses-section" style="display: none"
+            <section class="card card-list card-list-latest"
+                     id="kikar-statuses-section" style="display: none"
                      data-type="search" data-id="{{ object.name }}">
                 {% include 'kikar/_facebook_status_section_update_elem.html' %}
                 <header>
@@ -146,19 +162,25 @@
                     data-filter='feed__is_current=true&content__contains={{ object.name }}'>
                 </ul>
                 <footer style="text-align: center">
-                    <span id="loading-statuses-symbol"><i class="fa fa-2x fa-spinner fa-spin"></i> </span>
-                    <button id="statuses-more" class="btn btn-mini btn-expand-fb"
+                    <span id="loading-statuses-symbol"><i
+                            class="fa fa-2x fa-spinner fa-spin"></i> </span>
+                    <button id="statuses-more"
+                            class="btn btn-mini btn-expand-fb"
                             data-target="#kikar-facebook-updates-ul"
-                            data-offset='0'>{% trans "More Facebook Statuses" %} +
+                            data-offset='0'>{% trans "More Facebook Statuses" %}
+                        +
                     </button>
                 </footer>
             </section>
             {% ifnotequal object.type 'plenum' %}
                 <section class="card card-list">
-                    <header><h2><i class="fa fa-file-text"></i>{% trans 'MMM Documents' %}</h2></header>
+                    <header><h2><i
+                            class="fa fa-file-text"></i>{% trans 'MMM Documents' %}
+                    </h2></header>
                     <ul id="recent-mmm">
                         {% include "mks/mmm_partials.html" with object_list=object.sorted_mmm_documents %}
-                        <li><a href="mmm_documents/">{% trans 'more...' %}</a></li>
+                        <li><a href="mmm_documents/">{% trans 'more...' %}</a>
+                        </li>
                     </ul>
                 </section>
             {% endifnotequal %}
@@ -166,26 +188,30 @@
 
         <div class="span4">
             {% ifnotequal object.type 'plenum' %}
-                <aside class="sidebar sidebar-comments">
-                    <h2>{% trans "Suggested Agenda Topics" %}</h2>
-                    <ul id="committee-topics">
-                        <li class="agenda-mini">
-                            {% if user.is_authenticated %}
-                                {% if perms.committees.add_topic %}
-                                    <a class="btn"
-                                       href="{% url 'edit-committee-topic' object.id %}">{% trans "Suggest Topic" %}</a>
+                {% flag "show_committee_topics" %}
+                    <aside class="sidebar sidebar-comments">
+                        <h2>{% trans "Suggested Agenda Topics" %}</h2>
+                        <ul id="committee-topics">
+                            <li class="agenda-mini">
+                                {% if user.is_authenticated %}
+                                    {% if perms.committees.add_topic %}
+                                        <a class="btn"
+                                           href="{% url 'edit-committee-topic' object.id %}">{% trans "Suggest Topic" %}</a>
+                                    {% else %}
+                                        {% trans 'to suggest a topic' %},
+                                        {% trans 'Please' %}
+                                        <a class="bold-link"
+                                           href="{% url 'edit-profile' %}">{% trans 'validate your email' %}</a>
+                                    {% endif %}
                                 {% else %}
-                                    {% trans 'to suggest a topic' %}, {% trans 'Please' %}
-                                    <a class="bold-link"
-                                       href="{% url 'edit-profile' %}">{% trans 'validate your email' %}</a>
+                                    <a href='{% url 'login' %}?next={{ request.get_full_path }}'>{% trans 'Please login to suggest a topic' %}</a>
                                 {% endif %}
-                            {% else %}
-                                <a href='{% url 'login' %}?next={{ request.get_full_path }}'>{% trans 'Please login to suggest a topic' %}</a>
-                            {% endif %}
-                        </li>
-                        {% include "committees/_topics_summary.html" with object_list=topics %}
-                    </ul>
-                </aside>
+                            </li>
+                            {% include "committees/_topics_summary.html" with object_list=topics %}
+                        </ul>
+                    </aside>
+                {% endflag %}
+
             {% endifnotequal %}
 
             <aside class="sidebar sidebar-comments">
@@ -193,8 +219,10 @@
                 <ul class="annotations">
                     {% for a in annotations|slice:":5" %}
                         <li class="agenda-mini">
-                            <a rel="popover" href="{{ a.get_absolute_url }}" title="{{ a.flag_value }}">
-                                "...{{ a.selection }}..." ({{ a.content_object.header }})
+                            <a rel="popover" href="{{ a.get_absolute_url }}"
+                               title="{{ a.flag_value }}">
+                                "...{{ a.selection }}..."
+                                ({{ a.content_object.header }})
                                 <div class="tip" style="display:none">
                                     <div class="user_id">
                                         <a href="{% url 'public-profile' a.user.username %}">{% avatar a.user 45 %}

--- a/templates/committees/committee_list.html
+++ b/templates/committees/committee_list.html
@@ -1,8 +1,9 @@
 {% extends "site_base.html" %}
-{% load i18n i18ninclude mks_tags %}{% load static from staticfiles %}
+{% load i18n i18ninclude mks_tags waffle_tags %}{% load static from staticfiles %}
 {% block extratitle %}{% trans "Committees" %}{% endblock %}
 {% block keywords %}{{% trans "Committees" %}{% endblock %}
-{% block description %}{% trans "Committees" %} - {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
+{% block description %}{% trans "Committees" %} -
+    {% trans 'Open Knesset - Opening the Knesset to the public' %}{% endblock %}
 
 {% block extrajs %}
     <script src="{% static "js/jquery.raty.min.js" %}"></script>
@@ -14,7 +15,7 @@
 
         function setRating() { // will reuse it for ok-more callback
             $('[data-provider="rating"]').raty({
-                score: function() {
+                score: function () {
                     return $(this).data('rating');
                 }
             }).removeAttr('data-provider');
@@ -27,22 +28,27 @@
 {% block nav-committees %}class="active"{% endblock %}
 
 {% block breadcrumbs %}
-            <li class="active">{% trans "Committees" %}</li>
+    <li class="active">{% trans "Committees" %}</li>
 {% endblock %}
 
 {% block divcontent %}
 
-    <div id="committee-information-modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="committeeModalLabel" aria-hidden="true">
+    <div id="committee-information-modal" class="modal hide fade" tabindex="-1"
+         role="dialog" aria-labelledby="committeeModalLabel"
+         aria-hidden="true">
         <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
+            <button type="button" class="close" data-dismiss="modal"
+                    aria-hidden="true">x
+            </button>
             <h3 id="committeeModalLabel">{% trans "Committees" %}</h3>
         </div>
         <div class="modal-body">
-            <p><a href="help/">({% trans "what does committees do?"%})</a></p>
-	        {% i18ninclude "committees/committee_list_help.html" LANGUAGE_CODE %}
+            <p><a href="help/">({% trans "what does committees do?" %})</a></p>
+            {% i18ninclude "committees/committee_list_help.html" LANGUAGE_CODE %}
         </div>
         <div class="modal-footer">
-            <button class="btn" data-dismiss="modal" aria-hidden="true">{% trans "Close" %}</button>
+            <button class="btn" data-dismiss="modal"
+                    aria-hidden="true">{% trans "Close" %}</button>
         </div>
     </div>
 
@@ -50,38 +56,46 @@
         <div class="cards span8">
             <section class="card card-list">
                 <header>
-                    <h1><i class="fa fa-users"></i>{% trans "Committees" %}</h1>
-                    <a class="btn btn-mini btn-question" href="#committee-information-modal" data-toggle="modal">?</a>
+                    <h1><i class="fa fa-users"></i>{% trans "Committees" %}
+                    </h1>
+                    <a class="btn btn-mini btn-question"
+                       href="#committee-information-modal" data-toggle="modal">?</a>
                 </header>
                 <ul>
                     {% for o in committees %}
-                    <li>
+                        <li>
                         <p class="item-title">
-                        <a id="detail-{{ o.id }}" href="{% url 'committee-detail' o.id %}">{{o.name}}</a></p>
+                            <a id="detail-{{ o.id }}"
+                               href="{% url 'committee-detail' o.id %}">{{ o.name }}</a>
+                        </p>
 
-                        {% if o.description %}<p>{{ o.description|linebreaksbr }}</p>{% endif %}
-                        {% endfor %}
+                        {% if o.description %}
+                            <p>{{ o.description|linebreaksbr }}</p>{% endif %}
+                    {% endfor %}
                     </li>
                 </ul>
             </section>
         </div> <!-- span8 -->
 
         <div class="span4">
-            <aside class="sidebar sidebar-comments hidden">
-                <h2>{% trans "Suggested Agenda Topics" %}</h2>
-                <ul id="committee-topics">
-                {% include "committees/_topics_summary.html" with object_list=topics%}
-                </ul>
-                {% if topics_more %}
-                    <button class="btn btn-more" data-provide="okmore"
-                        data-loading-text="{% trans "Loading" %} ..."
-                        autocomplete="off" data-target="#committee-topics" 
-                        data-url="{% url 'committee-topics-more' %}"
-                        data-initial="{{INITIAL_TOPICS}}"
-                        data-callback="setRating"
+            {% flag "show_committee_topics" %}
+                <aside class="sidebar sidebar-comments">
+                    <h2>{% trans "Suggested Agenda Topics" %}</h2>
+                    <ul id="committee-topics">
+                        {% include "committees/_topics_summary.html" with object_list=topics %}
+                    </ul>
+                    {% if topics_more %}
+                        <button class="btn btn-more" data-provide="okmore"
+                                data-loading-text="{% trans "Loading" %} ..."
+                                autocomplete="off"
+                                data-target="#committee-topics"
+                                data-url="{% url 'committee-topics-more' %}"
+                                data-initial="{{ INITIAL_TOPICS }}"
+                                data-callback="setRating"
                         >{% trans "More" %} {% trans "Suggested Agenda Topics" %}</button>
-                {% endif %}
-            </aside>
+                    {% endif %}
+                </aside>
+            {% endflag %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
#### Relating issues 
Issue link and do the pull request resolves it. e.g:
- Resolves #782 

#### Change list
- update views of CommitteeDetailView and CommitteeListView to add topics to context only when 'show_committee_topics' flag is active.
- update respective templates to display topics sidebar pane only when flag is active.
- add tests.
