### PR TITLE
quick hack to mount the static committee pages on open knesset

### DIFF
--- a/committees/urls.py
+++ b/committees/urls.py
@@ -6,13 +6,41 @@ from views import (
     CommitteeListView, CommitteeDetailView, TopicListView, TopicsMoreView,
     TopicDetailView, delete_topic, delete_topic_rating, meeting_list_by_date,
     edit_topic, CommitteeMMMDocuments, UnpublishedProtocolslistView, FutureMeetingslistView)
+from django.http.response import HttpResponse, Http404
+import os
+
 
 meetings_list = MeetingsListView.as_view()
 unpublished_protocols_list = UnpublishedProtocolslistView.as_view()
 future_meetings_list = FutureMeetingslistView.as_view()
 
+
+def static_committees_index_view(request):
+    filepath = "/oknesset_web/committees/dist/committees/index.html"
+    if os.path.exists(filepath):
+        with open(filepath) as f:
+            return HttpResponse(f.read())
+    else:
+        return CommitteeListView.as_view()(request)
+
+
+def static_committees_page_view(request, *args):
+    filepath = "/oknesset_web/committees/dist/{}".format(request.path)
+    if os.path.exists(filepath):
+        with open(filepath) as f:
+            return HttpResponse(f.read())
+    else:
+        return Http404()
+
+
 committeesurlpatterns = patterns('',
-                                 url(r'^committee/$', CommitteeListView.as_view(), name='committee-list'),
+                                 # static committee pages
+                                 url(r'^committee/$', static_committees_index_view, name='committee-list'),
+                                 url(r'^committees/knesset-(\d+).html', static_committees_page_view),
+                                 url(r'^committees/(\d+).html', static_committees_page_view),
+                                 url(r'^meetings/(\d+)/(\d+)/(\d+).html', static_committees_page_view),
+                                 url(r'^committees/index.html', static_committees_page_view),
+
                                  url(r'^committee/more-topics/$', TopicsMoreView.as_view(),
                                      name='committee-topics-more'),
                                  url(r'^committee/(?P<pk>\d+)/$', CommitteeDetailView.as_view(),


### PR DESCRIPTION
sends the static committee html pages (generated from knesset-data-committees repo) to requests on open knesset

basically, just 1 url is replaces in open knesset - 

https://oknesset.org/committees will show the knesset-data-committees/dist/committees/index.html page

Other then that, all static page urls are added as additional urls to the existing open knesset committee pages

in the future we will also merge the urls - so we won't have duplication of content